### PR TITLE
Fix for reading the size of the padding element when it is greater than 1MP

### DIFF
--- a/src/classes/domRoutines.ts
+++ b/src/classes/domRoutines.ts
@@ -61,7 +61,7 @@ export class Routines {
   getSizeStyle(element: HTMLElement): number {
     this.checkElement(element);
     const size = element.style[this.horizontal ? 'width' : 'height'];
-    return parseInt(size as string, 10) || 0;
+    return parseFloat(size as string) || 0;
   }
 
   setSizeStyle(element: HTMLElement, value: number): void {

--- a/src/processes/clip.ts
+++ b/src/processes/clip.ts
@@ -27,13 +27,19 @@ export default class Clip extends BaseProcessFactory(CommonProcess.clip) {
       }
       item.hide();
       size[item.removeDirection] += item.size;
-      const padding = paddings.byDirection(item.removeDirection);
-      padding.size += item.size;
       return true;
     });
 
-    if (scroller.settings.onBeforeClip && itemsToRemove.length) {
-      scroller.settings.onBeforeClip(itemsToRemove.map(item => item.get()));
+    if (itemsToRemove.length) {
+      if (size[Direction.backward]) {
+        paddings.byDirection(Direction.backward).size += size[Direction.backward];
+      }
+      if (size[Direction.forward]) {
+        paddings.byDirection(Direction.forward).size += size[Direction.forward];
+      }
+      if (scroller.settings.onBeforeClip) {
+        scroller.settings.onBeforeClip(itemsToRemove.map(item => item.get()));
+      }
     }
 
     buffer.clip();


### PR DESCRIPTION
This is for https://github.com/dhilt/vscroll/issues/8 and https://github.com/dhilt/ngx-ui-scroll/issues/261.