### PR TITLE
Pause-resume methods fixes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vscroll",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vscroll",
-      "version": "1.6.0",
+      "version": "1.6.1",
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.3.1"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vscroll",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "description": "Virtual scroll engine",
   "main": "dist/bundles/vscroll.umd.js",
   "module": "dist/bundles/vscroll.esm5.js",

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,4 +1,4 @@
 export default {
   name: 'vscroll',
-  version: '1.6.0'
+  version: '1.6.1'
 };


### PR DESCRIPTION
We can't rely on `function.name` because bundler corrupts function names.
Instead, we should pass the name of the method explicitly.