### PR TITLE
Wrap internal logs with compile-time `vscroll_enableLogging` guard

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@
   - [Routines](#5-routines)
 - [Live](#live)
 - [Adapter API](#adapter-api)
+- [Compile-Time Logging Control](#compile-time-logging-control)
 - [Thanks](#thanks)
 
 ## Overview
@@ -278,6 +279,30 @@ console.log('The Workflow runs'); // 1st output
 ```
 
 VScroll will receive its own Adapter API documentation later, but for now please refer to [ngx-ui-scroll](https://github.com/dhilt/ngx-ui-scroll#adapter-api).
+
+## Compile-Time Logging Control
+
+`vscroll` includes detailed internal logging useful for debugging. To avoid unnecessary overhead in production, you can disable logging at compile time by defining a global constant:
+
+```js
+// webpack.config.js
+new webpack.DefinePlugin({
+  vscroll_enableLogging: JSON.stringify(false)
+});
+```
+
+Or when using ESBuild:
+
+```js
+import { build } from 'esbuild';
+
+build({
+  ...,
+  define: {
+    vscroll_enableLogging: JSON.stringify(false)
+  }
+});
+```
 
 ## Thanks
 

--- a/src/classes/adapter.ts
+++ b/src/classes/adapter.ts
@@ -132,11 +132,15 @@ export class Adapter<Item = unknown> implements IAdapter<Item> {
   private getWorkflowRunnerMethod(method: MethodResolver, name: AdapterPropName) {
     return (...args: unknown[]): Promise<AdapterMethodResult> => {
       if (!this.relax$) {
-        this.logger?.log?.(() => 'scroller is not initialized: ' + name + ' method is ignored');
+        if (typeof vscroll_enableLogging === 'undefined' || vscroll_enableLogging) {
+          this.logger?.log?.(() => 'scroller is not initialized: ' + name + ' method is ignored');
+        }
         return Promise.resolve(methodPreResult);
       }
       if (this.paused && !ALLOWED_METHODS_WHEN_PAUSED.includes(name)) {
-        this.logger?.log?.(() => 'scroller is paused: ' + name + ' method is ignored');
+        if (typeof vscroll_enableLogging === 'undefined' || vscroll_enableLogging) {
+          this.logger?.log?.(() => 'scroller is paused: ' + name + ' method is ignored');
+        }
         return Promise.resolve(methodPausedResult);
 
       }
@@ -337,7 +341,9 @@ export class Adapter<Item = unknown> implements IAdapter<Item> {
         return;
       }
       if (buffer.items.some(({ element }) => !element)) {
-        logger.log('skipping first/lastVisible set because not all buffered items are rendered at this moment');
+        if (typeof vscroll_enableLogging === 'undefined' || vscroll_enableLogging) {
+          logger.log('skipping first/lastVisible set because not all buffered items are rendered at this moment');
+        }
         return;
       }
       const direction = first ? Direction.backward : Direction.forward;
@@ -423,7 +429,9 @@ export class Adapter<Item = unknown> implements IAdapter<Item> {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   reset(options?: IDatasourceOptional): any {
     this.reloadCounter++;
-    this.logger.logAdapterMethod('reset', options, ` of ${this.reloadId}`);
+    if (typeof vscroll_enableLogging === 'undefined' || vscroll_enableLogging) {
+      this.logger.logAdapterMethod('reset', options, ` of ${this.reloadId}`);
+    }
     this.workflow.call({
       process: AdapterProcess.reset,
       status: ProcessStatus.start,
@@ -434,7 +442,9 @@ export class Adapter<Item = unknown> implements IAdapter<Item> {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   reload(options?: number | string): any {
     this.reloadCounter++;
-    this.logger.logAdapterMethod('reload', options, ` of ${this.reloadId}`);
+    if (typeof vscroll_enableLogging === 'undefined' || vscroll_enableLogging) {
+      this.logger.logAdapterMethod('reload', options, ` of ${this.reloadId}`);
+    }
     this.workflow.call({
       process: AdapterProcess.reload,
       status: ProcessStatus.start,
@@ -445,7 +455,9 @@ export class Adapter<Item = unknown> implements IAdapter<Item> {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   append(_options: AdapterAppendOptions<Item> | unknown, eof?: boolean): any {
     const options = convertAppendArgs(false, _options, eof); // support old signature
-    this.logger.logAdapterMethod('append', [options.items, options.eof]);
+    if (typeof vscroll_enableLogging === 'undefined' || vscroll_enableLogging) {
+      this.logger.logAdapterMethod('append', [options.items, options.eof]);
+    }
     this.workflow.call({
       process: AdapterProcess.append,
       status: ProcessStatus.start,
@@ -456,7 +468,9 @@ export class Adapter<Item = unknown> implements IAdapter<Item> {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   prepend(_options: AdapterPrependOptions<Item> | unknown, bof?: boolean): any {
     const options = convertAppendArgs(true, _options, bof); // support old signature
-    this.logger.logAdapterMethod('prepend', [options.items, options.bof]);
+    if (typeof vscroll_enableLogging === 'undefined' || vscroll_enableLogging) {
+      this.logger.logAdapterMethod('prepend', [options.items, options.bof]);
+    }
     this.workflow.call({
       process: AdapterProcess.prepend,
       status: ProcessStatus.start,
@@ -466,7 +480,9 @@ export class Adapter<Item = unknown> implements IAdapter<Item> {
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   check(): any {
-    this.logger.logAdapterMethod('check');
+    if (typeof vscroll_enableLogging === 'undefined' || vscroll_enableLogging) {
+      this.logger.logAdapterMethod('check');
+    }
     this.workflow.call({
       process: AdapterProcess.check,
       status: ProcessStatus.start
@@ -476,7 +492,9 @@ export class Adapter<Item = unknown> implements IAdapter<Item> {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   remove(options: AdapterRemoveOptions<Item> | ItemsPredicate<Item>): any {
     options = convertRemoveArgs(options); // support old signature
-    this.logger.logAdapterMethod('remove', options);
+    if (typeof vscroll_enableLogging === 'undefined' || vscroll_enableLogging) {
+      this.logger.logAdapterMethod('remove', options);
+    }
     this.workflow.call({
       process: AdapterProcess.remove,
       status: ProcessStatus.start,
@@ -486,7 +504,9 @@ export class Adapter<Item = unknown> implements IAdapter<Item> {
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   clip(options?: AdapterClipOptions): any {
-    this.logger.logAdapterMethod('clip', options);
+    if (typeof vscroll_enableLogging === 'undefined' || vscroll_enableLogging) {
+      this.logger.logAdapterMethod('clip', options);
+    }
     this.workflow.call({
       process: AdapterProcess.clip,
       status: ProcessStatus.start,
@@ -496,7 +516,9 @@ export class Adapter<Item = unknown> implements IAdapter<Item> {
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   insert(options: AdapterInsertOptions<Item>): any {
-    this.logger.logAdapterMethod('insert', options);
+    if (typeof vscroll_enableLogging === 'undefined' || vscroll_enableLogging) {
+      this.logger.logAdapterMethod('insert', options);
+    }
     this.workflow.call({
       process: AdapterProcess.insert,
       status: ProcessStatus.start,
@@ -506,7 +528,9 @@ export class Adapter<Item = unknown> implements IAdapter<Item> {
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   replace(options: AdapterReplaceOptions<Item>): any {
-    this.logger.logAdapterMethod('replace', options);
+    if (typeof vscroll_enableLogging === 'undefined' || vscroll_enableLogging) {
+      this.logger.logAdapterMethod('replace', options);
+    }
     this.workflow.call({
       process: AdapterProcess.replace,
       status: ProcessStatus.start,
@@ -516,7 +540,9 @@ export class Adapter<Item = unknown> implements IAdapter<Item> {
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   update(options: AdapterUpdateOptions<Item>): any {
-    this.logger.logAdapterMethod('update', options);
+    if (typeof vscroll_enableLogging === 'undefined' || vscroll_enableLogging) {
+      this.logger.logAdapterMethod('update', options);
+    }
     this.workflow.call({
       process: AdapterProcess.update,
       status: ProcessStatus.start,
@@ -526,7 +552,9 @@ export class Adapter<Item = unknown> implements IAdapter<Item> {
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   pause(): any {
-    this.logger.logAdapterMethod('pause');
+    if (typeof vscroll_enableLogging === 'undefined' || vscroll_enableLogging) {
+      this.logger.logAdapterMethod('pause');
+    }
     this.workflow.call({
       process: AdapterProcess.pause,
       status: ProcessStatus.start
@@ -535,7 +563,9 @@ export class Adapter<Item = unknown> implements IAdapter<Item> {
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   resume(): any {
-    this.logger.logAdapterMethod('resume');
+    if (typeof vscroll_enableLogging === 'undefined' || vscroll_enableLogging) {
+      this.logger.logAdapterMethod('resume');
+    }
     this.workflow.call({
       process: AdapterProcess.pause,
       status: ProcessStatus.start,
@@ -545,7 +575,9 @@ export class Adapter<Item = unknown> implements IAdapter<Item> {
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   fix(options: AdapterFixOptions<Item>): any {
-    this.logger.logAdapterMethod('fix', options);
+    if (typeof vscroll_enableLogging === 'undefined' || vscroll_enableLogging) {
+      this.logger.logAdapterMethod('fix', options);
+    }
     this.workflow.call({
       process: AdapterProcess.fix,
       status: ProcessStatus.start,
@@ -576,7 +608,9 @@ export class Adapter<Item = unknown> implements IAdapter<Item> {
         };
       }
       const success = reloadId === this.reloadId;
-      this.logger?.log?.(() => !success ? `relax promise cancelled due to ${reloadId} != ${this.reloadId}` : void 0);
+      if (typeof vscroll_enableLogging === 'undefined' || vscroll_enableLogging) {
+        this.logger?.log?.(() => !success ? `relax promise cancelled due to ${reloadId} != ${this.reloadId}` : void 0);
+      }
       return {
         immediate,
         success,
@@ -587,7 +621,9 @@ export class Adapter<Item = unknown> implements IAdapter<Item> {
 
   relax(callback?: () => void): Promise<AdapterMethodResult> {
     const reloadId = this.reloadId;
-    this.logger.logAdapterMethod('relax', callback, ` of ${reloadId}`);
+    if (typeof vscroll_enableLogging === 'undefined' || vscroll_enableLogging) {
+      this.logger.logAdapterMethod('relax', callback, ` of ${reloadId}`);
+    }
     if (!this.init) {
       return Promise.resolve(methodPreResult);
     }
@@ -600,7 +636,9 @@ export class Adapter<Item = unknown> implements IAdapter<Item> {
   }
 
   showLog(): void {
-    this.logger.logAdapterMethod('showLog');
-    this.logger.logForce();
+    if (typeof vscroll_enableLogging === 'undefined' || vscroll_enableLogging) {
+      this.logger.logAdapterMethod('showLog');
+      this.logger.logForce();
+    }
   }
 }

--- a/src/classes/buffer.ts
+++ b/src/classes/buffer.ts
@@ -65,15 +65,21 @@ export class Buffer<Data> {
     const start = this.startIndexUser;
     let index = Number(newStartIndex);
     if (Number.isNaN(index)) {
-      this.logger.log(() => `fallback startIndex to settings.startIndex (${start})`);
+      if (typeof vscroll_enableLogging === 'undefined' || vscroll_enableLogging) {
+        this.logger.log(() => `fallback startIndex to settings.startIndex (${start})`);
+      }
       index = start;
     }
     if (index < min) {
-      this.logger.log(() => `setting startIndex to settings.minIndex (${min}) because ${index} < ${min}`);
+      if (typeof vscroll_enableLogging === 'undefined' || vscroll_enableLogging) {
+        this.logger.log(() => `setting startIndex to settings.minIndex (${min}) because ${index} < ${min}`);
+      }
       index = min;
     }
     if (index > max) {
-      this.logger.log(() => `setting startIndex to settings.maxIndex (${max}) because ${index} > ${max}`);
+      if (typeof vscroll_enableLogging === 'undefined' || vscroll_enableLogging) {
+        this.logger.log(() => `setting startIndex to settings.maxIndex (${max}) because ${index} > ${max}`);
+      }
       index = max;
     }
     this.startIndex = index;

--- a/src/classes/buffer/cache.ts
+++ b/src/classes/buffer/cache.ts
@@ -85,7 +85,9 @@ export class Cache<Data = unknown> {
 
   recalculateDefaultSize(): boolean {
     if (this.defaultSize.recalculate(this.size)) {
-      this.logger.log(() => `default size has been updated: ${this.defaultSize.get()}`);
+      if (typeof vscroll_enableLogging === 'undefined' || vscroll_enableLogging) {
+        this.logger.log(() => `default size has been updated: ${this.defaultSize.get()}`);
+      }
       return true;
     }
     return false;

--- a/src/classes/buffer/checkCall.ts
+++ b/src/classes/buffer/checkCall.ts
@@ -14,14 +14,20 @@ export class CheckBufferCall<Data> {
 
   fillEmpty(items: Data[], before?: number, after?: number): boolean {
     if (!items.length) {
-      this.logger.log('no items to fill the buffer; empty list');
+      if (typeof vscroll_enableLogging === 'undefined' || vscroll_enableLogging) {
+        this.logger.log('no items to fill the buffer; empty list');
+      }
       return false;
     }
     if (!Number.isInteger(before) && !Number.isInteger(after)) {
-      this.logger.log('no items to fill the buffer; wrong indexes');
+      if (typeof vscroll_enableLogging === 'undefined' || vscroll_enableLogging) {
+        this.logger.log('no items to fill the buffer; wrong indexes');
+      }
       return false;
     }
-    this.logger.log(() => `going to fill the buffer with ${items.length} item(s)`);
+    if (typeof vscroll_enableLogging === 'undefined' || vscroll_enableLogging) {
+      this.logger.log(() => `going to fill the buffer with ${items.length} item(s)`);
+    }
     return true;
   }
 
@@ -32,7 +38,9 @@ export class CheckBufferCall<Data> {
       (Number.isInteger(index) && index === item.$index)
     );
     if (!found) {
-      this.logger.log('no items to insert in buffer; empty predicate\'s result');
+      if (typeof vscroll_enableLogging === 'undefined' || vscroll_enableLogging) {
+        this.logger.log('no items to insert in buffer; empty predicate\'s result');
+      }
       return NaN;
     }
     return found.$index;
@@ -40,25 +48,33 @@ export class CheckBufferCall<Data> {
 
   insertVirtual(items: Data[], index: number, direction: Direction): boolean {
     if (!items.length) {
-      this.logger.log('no items to insert virtually; empty list');
+      if (typeof vscroll_enableLogging === 'undefined' || vscroll_enableLogging) {
+        this.logger.log('no items to insert virtually; empty list');
+      }
       return false;
     }
     const { firstIndex, lastIndex, finiteAbsMinIndex, finiteAbsMaxIndex } = this.context;
     if (index < finiteAbsMinIndex || index > finiteAbsMaxIndex) {
-      this.logger.log(() =>
-        'no items to insert virtually; ' +
-        `selected index (${index}) does not match virtual area [${finiteAbsMinIndex}..${finiteAbsMaxIndex}]`
-      );
+      if (typeof vscroll_enableLogging === 'undefined' || vscroll_enableLogging) {
+        this.logger.log(() =>
+          'no items to insert virtually; ' +
+          `selected index (${index}) does not match virtual area [${finiteAbsMinIndex}..${finiteAbsMaxIndex}]`
+        );
+      }
       return false;
     }
     const before = direction === Direction.backward;
     if (!(index < firstIndex + (before ? 1 : 0) || index > lastIndex - (before ? 0 : 1))) {
-      this.logger.log(() =>
-        `no items to insert virtually; selected index (${index}) belongs Buffer [${firstIndex}..${lastIndex}]`
-      );
+      if (typeof vscroll_enableLogging === 'undefined' || vscroll_enableLogging) {
+        this.logger.log(() =>
+          `no items to insert virtually; selected index (${index}) belongs Buffer [${firstIndex}..${lastIndex}]`
+        );
+      }
       return false;
     }
-    this.logger.log(() => `going to insert ${items.length} item(s) virtually`);
+    if (typeof vscroll_enableLogging === 'undefined' || vscroll_enableLogging) {
+      this.logger.log(() => `going to insert ${items.length} item(s) virtually`);
+    }
     return true;
   }
 

--- a/src/classes/viewport.ts
+++ b/src/classes/viewport.ts
@@ -34,14 +34,18 @@ export class Viewport {
   setPosition(value: number): number {
     const oldPosition = this.scrollPosition;
     if (oldPosition === value) {
-      this.logger.log(() => ['setting scroll position at', value, '[cancelled]']);
+      if (typeof vscroll_enableLogging === 'undefined' || vscroll_enableLogging) {
+        this.logger.log(() => ['setting scroll position at', value, '[cancelled]']);
+      }
       return value;
     }
     this.routines.setScrollPosition(value);
     const position = this.scrollPosition;
-    this.logger.log(() => [
-      'setting scroll position at', position, ...(position !== value ? [`(${value})`] : [])
-    ]);
+    if (typeof vscroll_enableLogging === 'undefined' || vscroll_enableLogging) {
+      this.logger.log(() => [
+        'setting scroll position at', position, ...(position !== value ? [`(${value})`] : [])
+      ]);
+    }
     return position;
   }
 

--- a/src/global-defs.ts
+++ b/src/global-defs.ts
@@ -1,0 +1,5 @@
+declare global {
+  const vscroll_enableLogging: boolean;
+}
+
+export default {};

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,5 @@
+import './global-defs';
+
 import { Workflow } from './workflow';
 import { makeDatasource } from './classes/datasource';
 import { Routines } from './classes/domRoutines';

--- a/src/processes/adapter/check.ts
+++ b/src/processes/adapter/check.ts
@@ -31,7 +31,9 @@ export default class Check extends BaseAdapterProcessFactory(AdapterProcess.chec
       );
     }
 
-    scroller.logger.stat('check');
+    if (typeof vscroll_enableLogging === 'undefined' || vscroll_enableLogging) {
+      scroller.logger.stat('check');
+    }
 
     workflow.call({
       process: Check.process,

--- a/src/processes/adapter/fix.ts
+++ b/src/processes/adapter/fix.ts
@@ -79,7 +79,9 @@ export default class Fix extends BaseAdapterProcessFactory(AdapterProcess.fix) {
     const updater = () => updateReference = true;
     buffer.items.forEach(item => value(item.get(), updater));
     if (updateReference) {
-      logger.log(() => 'update Buffer.items reference');
+      if (typeof vscroll_enableLogging === 'undefined' || vscroll_enableLogging) {
+        logger.log(() => 'update Buffer.items reference');
+      }
       buffer.items = [...buffer.items];
     }
   }
@@ -87,7 +89,9 @@ export default class Fix extends BaseAdapterProcessFactory(AdapterProcess.fix) {
   static scrollToItem(scroller: Scroller, value: ItemsPredicate, options?: boolean | ScrollIntoViewOptions): void {
     const found = scroller.buffer.items.find(item => value(item.get()));
     if (!found) {
-      scroller.logger.log(() => 'scrollToItem cancelled, item not found');
+      if (typeof vscroll_enableLogging === 'undefined' || vscroll_enableLogging) {
+        scroller.logger.log(() => 'scrollToItem cancelled, item not found');
+      }
       return;
     }
     found.scrollTo(options);

--- a/src/processes/adapter/pause.ts
+++ b/src/processes/adapter/pause.ts
@@ -8,7 +8,9 @@ export default class Pause extends BaseAdapterProcessFactory(AdapterProcess.paus
 
     // pause branch
     if (!resume && !scroller.state.paused.get()) {
-      scroller.logger.log('pause scroller');
+      if (typeof vscroll_enableLogging === 'undefined' || vscroll_enableLogging) {
+        scroller.logger.log('pause scroller');
+      }
       scroller.state.paused.set(true);
       scroller.workflow.call({
         process: AdapterProcess.pause,
@@ -17,7 +19,9 @@ export default class Pause extends BaseAdapterProcessFactory(AdapterProcess.paus
       return;
     }
 
-    scroller.logger.log('resume scroller');
+    if (typeof vscroll_enableLogging === 'undefined' || vscroll_enableLogging) {
+      scroller.logger.log('resume scroller');
+    }
     scroller.state.paused.set(false);
     scroller.workflow.call({
       process: AdapterProcess.pause,

--- a/src/processes/adapter/remove.ts
+++ b/src/processes/adapter/remove.ts
@@ -42,7 +42,9 @@ export default class Remove extends BaseAdapterProcessFactory(AdapterProcess.rem
     if (!shouldBuffered && !shouldVirtual) {
       return false;
     }
-    scroller.logger.stat('after remove');
+    if (typeof vscroll_enableLogging === 'undefined' || vscroll_enableLogging) {
+      scroller.logger.stat('after remove');
+    }
     return true;
   }
 
@@ -101,7 +103,9 @@ export default class Remove extends BaseAdapterProcessFactory(AdapterProcess.rem
     }
 
     // virtual removal
-    scroller.logger.log(() => `going to remove ${toRemove.length} item(s) virtually`);
+    if (typeof vscroll_enableLogging === 'undefined' || vscroll_enableLogging) {
+      scroller.logger.log(() => `going to remove ${toRemove.length} item(s) virtually`);
+    }
     buffer.removeVirtually(toRemove, !!increase);
     buffer.checkDefaultSize();
     Remove.shiftFirstVisibleIndex(scroller, toRemove, !!increase);

--- a/src/processes/adapter/replace.ts
+++ b/src/processes/adapter/replace.ts
@@ -24,7 +24,9 @@ export default class Replace extends BaseAdapterProcessFactory(AdapterProcess.re
       .map(item => item.$index);
 
     if (!toRemove.length) {
-      scroller.logger.log('no items to be replaced');
+      if (typeof vscroll_enableLogging === 'undefined' || vscroll_enableLogging) {
+        scroller.logger.log('no items to be replaced');
+      }
       return false;
     }
 

--- a/src/processes/adapter/update.ts
+++ b/src/processes/adapter/update.ts
@@ -23,7 +23,9 @@ export default class Update extends BaseAdapterProcessFactory(AdapterProcess.upd
   static doUpdate(scroller: Scroller, params: AdapterUpdateOptions): boolean {
     const { buffer, viewport, state: { fetch }, routines, logger } = scroller;
     if (!buffer.items) {
-      logger.log(() => 'no items in Buffer');
+      if (typeof vscroll_enableLogging === 'undefined' || vscroll_enableLogging) {
+        logger.log(() => 'no items in Buffer');
+      }
       return false;
     }
     const { item: firstItem, index: firstIndex, diff: firstItemDiff } =
@@ -43,19 +45,23 @@ export default class Update extends BaseAdapterProcessFactory(AdapterProcess.upd
     }
 
     toRemove.forEach(item => item.hide());
-    logger.log(() => toRemove.length
-      ? 'items to remove: [' + toRemove.map(({ $index }) => $index).join(',') + ']'
-      : 'no items to remove'
-    );
+    if (typeof vscroll_enableLogging === 'undefined' || vscroll_enableLogging) {
+      logger.log(() => toRemove.length
+        ? 'items to remove: [' + toRemove.map(({ $index }) => $index).join(',') + ']'
+        : 'no items to remove'
+      );
+    }
     if (toRemove.length) { // insertions will be processed on render
       buffer.checkDefaultSize();
     }
 
     const toRender = buffer.items.filter(({ toInsert }) => toInsert);
-    logger.log(() => toRender.length
-      ? 'items to render: [' + toRender.map(({ $index }) => $index).join(',') + ']'
-      : 'no items to render'
-    );
+    if (typeof vscroll_enableLogging === 'undefined' || vscroll_enableLogging) {
+      logger.log(() => toRender.length
+        ? 'items to render: [' + toRender.map(({ $index }) => $index).join(',') + ']'
+        : 'no items to render'
+      );
+    }
 
     fetch.update(trackedIndex, delta, toRender, toRemove);
     return !!toRemove.length || !!toRender.length;

--- a/src/processes/adjust.ts
+++ b/src/processes/adjust.ts
@@ -59,15 +59,19 @@ export default class Adjust extends BaseProcessFactory(CommonProcess.adjust) {
       } else {
         fwdSize += viewportSizeDiff;
       }
-      scroller.logger.log(() =>
-        inverse ? 'backward' : 'forward' + ` padding will be increased by ${viewportSizeDiff} to fill the viewport`
-      );
+      if (typeof vscroll_enableLogging === 'undefined' || vscroll_enableLogging) {
+        scroller.logger.log(() =>
+          inverse ? 'backward' : 'forward' + ` padding will be increased by ${viewportSizeDiff} to fill the viewport`
+        );
+      }
     }
 
     backward.size = bwdSize;
     forward.size = fwdSize;
 
-    scroller.logger.stat('after paddings adjustments');
+    if (typeof vscroll_enableLogging === 'undefined' || vscroll_enableLogging) {
+      scroller.logger.stat('after paddings adjustments');
+    }
   }
 
   static calculatePosition(scroller: Scroller): number {
@@ -76,7 +80,9 @@ export default class Adjust extends BaseProcessFactory(CommonProcess.adjust) {
 
     // increase the position to meet the expectation of the first visible item
     if (!isNaN(fetch.firstVisible.index) && !isNaN(buffer.firstIndex)) {
-      scroller.logger.log(`first index = ${fetch.firstVisible.index}, delta = ${fetch.firstVisible.delta}`);
+      if (typeof vscroll_enableLogging === 'undefined' || vscroll_enableLogging) {
+        scroller.logger.log(`first index = ${fetch.firstVisible.index}, delta = ${fetch.firstVisible.delta}`);
+      }
       const shouldCheckPreSizeExpectation = fetch.shouldCheckPreSizeExpectation(buffer.lastIndex);
       buffer.items.forEach(item => {
         // 1) shift of the buffered items before the first visible item
@@ -99,7 +105,9 @@ export default class Adjust extends BaseProcessFactory(CommonProcess.adjust) {
     if (scroll.positionBeforeAsync !== null) {
       const diff = render.positionBefore - scroll.positionBeforeAsync;
       if (diff !== 0) {
-        scroller.logger.log(`shift position due to fetch-render difference (${diff})`);
+        if (typeof vscroll_enableLogging === 'undefined' || vscroll_enableLogging) {
+          scroller.logger.log(`shift position due to fetch-render difference (${diff})`);
+        }
         position += diff;
       }
     }
@@ -133,7 +141,9 @@ export default class Adjust extends BaseProcessFactory(CommonProcess.adjust) {
     const shift = Math.min(size, diff);
     if (shift) {
       viewport.paddings.forward.size += shift;
-      scroller.logger.log(`increase fwd padding due to lack of items (${diff} -> ${shift})`);
+      if (typeof vscroll_enableLogging === 'undefined' || vscroll_enableLogging) {
+        scroller.logger.log(`increase fwd padding due to lack of items (${diff} -> ${shift})`);
+      }
     }
   }
 
@@ -156,7 +166,9 @@ export default class Adjust extends BaseProcessFactory(CommonProcess.adjust) {
       }
       scroll.syntheticFulfill = true;
       viewport.scrollPosition = position;
-      scroller.logger.stat('after scroll adjustment' + diffLog);
+      if (typeof vscroll_enableLogging === 'undefined' || vscroll_enableLogging) {
+        scroller.logger.stat('after scroll adjustment' + diffLog);
+      }
       done();
     });
   }

--- a/src/processes/clip.ts
+++ b/src/processes/clip.ts
@@ -19,7 +19,9 @@ export default class Clip extends BaseProcessFactory(CommonProcess.clip) {
     const { buffer, viewport: { paddings }, state: { clip }, logger } = scroller;
     const size = { [Direction.backward]: 0, [Direction.forward]: 0 };
 
-    logger.stat(`before clip (${++clip.callCount})`);
+    if (typeof vscroll_enableLogging === 'undefined' || vscroll_enableLogging) {
+      logger.stat(`before clip (${++clip.callCount})`);
+    }
 
     const itemsToRemove = buffer.items.filter(item => {
       if (!item.toRemove) {
@@ -44,19 +46,21 @@ export default class Clip extends BaseProcessFactory(CommonProcess.clip) {
 
     buffer.clip();
 
-    logger.log(() => {
-      const list = itemsToRemove.map(({ $index }) => $index);
-      return list.length
-        ? [
-          `clipped ${list.length} item(s) from Buffer` +
-          (size.backward ? `, +${size.backward} fwd px` : '') +
-          (size.forward ? `, +${size.forward} bwd px` : '') +
-          `, range: [${list[0]}..${list[list.length - 1]}]`
-        ]
-        : 'clipped 0 items from Buffer';
-    });
+    if (typeof vscroll_enableLogging === 'undefined' || vscroll_enableLogging) {
+      logger.log(() => {
+        const list = itemsToRemove.map(({ $index }) => $index);
+        return list.length
+          ? [
+            `clipped ${list.length} item(s) from Buffer` +
+            (size.backward ? `, +${size.backward} fwd px` : '') +
+            (size.forward ? `, +${size.forward} bwd px` : '') +
+            `, range: [${list[0]}..${list[list.length - 1]}]`
+          ]
+          : 'clipped 0 items from Buffer';
+      });
 
-    logger.stat('after clip');
+      logger.stat('after clip');
+    }
   }
 
 }

--- a/src/processes/fetch.ts
+++ b/src/processes/fetch.ts
@@ -22,10 +22,12 @@ export default class Fetch extends BaseProcessFactory(CommonProcess.fetch) {
 
     const box = {
       success: (data: unknown[]) => {
-        scroller.logger.log(() =>
-          `resolved ${data.length} items ` +
-          `(index = ${scroller.state.fetch.index}, count = ${scroller.state.fetch.count})`
-        );
+        if (typeof vscroll_enableLogging === 'undefined' || vscroll_enableLogging) {
+          scroller.logger.log(() =>
+            `resolved ${data.length} items ` +
+            `(index = ${scroller.state.fetch.index}, count = ${scroller.state.fetch.count})`
+          );
+        }
         scroller.state.fetch.newItemsData = data;
         workflow.call({
           process: Fetch.process,

--- a/src/processes/init.ts
+++ b/src/processes/init.ts
@@ -9,7 +9,9 @@ export default class Init extends BaseProcessFactory(CommonProcess.init) {
   static run(scroller: Scroller, process: ProcessName): void {
     const { state, workflow } = scroller;
     const isInitial = initProcesses.includes(process);
-    scroller.logger.logCycle(true);
+    if (typeof vscroll_enableLogging === 'undefined' || vscroll_enableLogging) {
+      scroller.logger.logCycle(true);
+    }
     state.startWorkflowCycle(isInitial, process);
     workflow.call({
       process: Init.process,

--- a/src/processes/misc/base.ts
+++ b/src/processes/misc/base.ts
@@ -31,7 +31,9 @@ export const BaseAdapterProcessFactory = (process: AdapterProcess): IBaseAdapter
             [key]: value
           }), {} as T);
       } else {
-        scroller.logger.log(() => result.data.showErrors());
+        if (typeof vscroll_enableLogging === 'undefined' || vscroll_enableLogging) {
+          scroller.logger.log(() => result.data.showErrors());
+        }
         if (!ignoreErrors) {
           scroller.workflow.call({
             process,

--- a/src/processes/preClip.ts
+++ b/src/processes/preClip.ts
@@ -23,17 +23,21 @@ export default class PreClip extends BaseProcessFactory(CommonProcess.preClip) {
     }
     const firstIndex = fetch.first.indexBuffer;
     const lastIndex = fetch.last.indexBuffer;
-    scroller.logger.log(() =>
-      `looking for ${fetch.direction ? 'anti-' + fetch.direction + ' ' : ''}items ` +
-      `that are out of [${firstIndex}..${lastIndex}] range`);
+    if (typeof vscroll_enableLogging === 'undefined' || vscroll_enableLogging) {
+      scroller.logger.log(() =>
+        `looking for ${fetch.direction ? 'anti-' + fetch.direction + ' ' : ''}items ` +
+        `that are out of [${firstIndex}..${lastIndex}] range`);
+    }
     if (PreClip.isBackward(scroller, firstIndex)) {
       PreClip.prepareClipByDirection(scroller, Direction.backward, firstIndex);
     }
     if (PreClip.isForward(scroller, lastIndex)) {
       PreClip.prepareClipByDirection(scroller, Direction.forward, lastIndex);
     }
-    if (!clip.doClip) {
-      scroller.logger.log('skipping clip [no items to clip]');
+    if (typeof vscroll_enableLogging === 'undefined' || vscroll_enableLogging) {
+      if (!clip.doClip) {
+        scroller.logger.log('skipping clip [no items to clip]');
+      }
     }
     return;
   }
@@ -41,15 +45,21 @@ export default class PreClip extends BaseProcessFactory(CommonProcess.preClip) {
   static shouldNotClip(scroller: Scroller): boolean {
     const { settings, buffer, state } = scroller;
     if (settings.infinite && !state.clip.force) {
-      scroller.logger.log('skipping clip [infinite mode]');
+      if (typeof vscroll_enableLogging === 'undefined' || vscroll_enableLogging) {
+        scroller.logger.log('skipping clip [infinite mode]');
+      }
       return true;
     }
     if (!buffer.size) {
-      scroller.logger.log('skipping clip [empty buffer]');
+      if (typeof vscroll_enableLogging === 'undefined' || vscroll_enableLogging) {
+        scroller.logger.log('skipping clip [empty buffer]');
+      }
       return true;
     }
     if (state.cycle.isInitial) {
-      scroller.logger.log('skipping clip [initial cycle]');
+      if (typeof vscroll_enableLogging === 'undefined' || vscroll_enableLogging) {
+        scroller.logger.log('skipping clip [initial cycle]');
+      }
       return true;
     }
     return false;

--- a/src/processes/preFetch.ts
+++ b/src/processes/preFetch.ts
@@ -36,7 +36,9 @@ export default class PreFetch extends BaseProcessFactory(CommonProcess.preFetch)
     PreFetch.setPositions(scroller);
     PreFetch.setFirstIndex(scroller);
     PreFetch.setLastIndex(scroller);
-    scroller.logger.fetch();
+    if (typeof vscroll_enableLogging === 'undefined' || vscroll_enableLogging) {
+      scroller.logger.fetch();
+    }
   }
 
   static setPositions(scroller: Scroller): void {
@@ -61,9 +63,11 @@ export default class PreFetch extends BaseProcessFactory(CommonProcess.preFetch)
     for (let index = buffer.finiteAbsMinIndex; index < buffer.startIndex; index++) {
       startDelta += buffer.getSizeByIndex(index);
     }
-    scroller.logger.log(() => [
-      `start delta is ${startDelta}`, ...(offset ? [` (+${offset} offset)`] : [])
-    ]);
+    if (typeof vscroll_enableLogging === 'undefined' || vscroll_enableLogging) {
+      scroller.logger.log(() => [
+        `start delta is ${startDelta}`, ...(offset ? [` (+${offset} offset)`] : [])
+      ]);
+    }
     return startDelta;
   }
 
@@ -73,9 +77,13 @@ export default class PreFetch extends BaseProcessFactory(CommonProcess.preFetch)
     let firstIndex = buffer.startIndex;
     let firstIndexPosition = 0;
     if (state.cycle.innerLoop.isInitial) {
-      scroller.logger.log('skipping fetch backward direction [initial loop]');
+      if (typeof vscroll_enableLogging === 'undefined' || vscroll_enableLogging) {
+        scroller.logger.log('skipping fetch backward direction [initial loop]');
+      }
     } else if (!buffer.defaultSize) {
-      scroller.logger.log('skipping fetch backward direction [no item size]');
+      if (typeof vscroll_enableLogging === 'undefined' || vscroll_enableLogging) {
+        scroller.logger.log('skipping fetch backward direction [no item size]');
+      }
     } else {
       let position = firstIndexPosition;
       let index = firstIndex;
@@ -120,7 +128,9 @@ export default class PreFetch extends BaseProcessFactory(CommonProcess.preFetch)
     if (!buffer.defaultSize) {
       // just to fetch forward bufferSize items if neither averageItemSize nor itemSize are present
       lastIndex = buffer.startIndex + settings.bufferSize - 1;
-      scroller.logger.log('forcing fetch forward direction [no item size]');
+      if (typeof vscroll_enableLogging === 'undefined' || vscroll_enableLogging) {
+        scroller.logger.log('forcing fetch forward direction [no item size]');
+      }
     } else {
       let index = first.indexBuffer;
       let position = first.position;
@@ -174,8 +184,10 @@ export default class PreFetch extends BaseProcessFactory(CommonProcess.preFetch)
     }
     fetch.first.index = Math.max(pack[0], buffer.absMinIndex);
     fetch.last.index = Math.min(pack[pack.length - 1], buffer.absMaxIndex);
-    if (fetch.first.index !== firstIndex || fetch.last.index !== lastIndex) {
-      scroller.logger.fetch('after Buffer flushing');
+    if (typeof vscroll_enableLogging === 'undefined' || vscroll_enableLogging) {
+      if (fetch.first.index !== firstIndex || fetch.last.index !== lastIndex) {
+        scroller.logger.fetch('after Buffer flushing');
+      }
     }
   }
 
@@ -194,8 +206,10 @@ export default class PreFetch extends BaseProcessFactory(CommonProcess.preFetch)
     if (fetchLast < bufferFirst) {
       fetch.last.index = fetch.last.indexBuffer = bufferFirst - 1;
     }
-    if (fetch.first.index !== fetchFirst || fetch.last.index !== fetchLast) {
-      scroller.logger.fetch('after Buffer filling (no clip case)');
+    if (typeof vscroll_enableLogging === 'undefined' || vscroll_enableLogging) {
+      if (fetch.first.index !== fetchFirst || fetch.last.index !== fetchLast) {
+        scroller.logger.fetch('after Buffer filling (no clip case)');
+      }
     }
   }
 
@@ -222,7 +236,9 @@ export default class PreFetch extends BaseProcessFactory(CommonProcess.preFetch)
       }
     }
     if (fetch.first.index !== firstIndex || fetch.last.index !== lastIndex) {
-      scroller.logger.fetch('after bufferSize adjustment');
+      if (typeof vscroll_enableLogging === 'undefined' || vscroll_enableLogging) {
+        scroller.logger.fetch('after bufferSize adjustment');
+      }
       PreFetch.skipBufferedItems(scroller);
     }
   }
@@ -235,18 +251,24 @@ export default class PreFetch extends BaseProcessFactory(CommonProcess.preFetch)
         direction = fetch.last.index < buffer.items[0].$index ? Direction.backward : Direction.forward;
       }
       fetch.direction = direction;
-      scroller.logger.log(() => `fetch direction is "${direction}"`);
+      if (typeof vscroll_enableLogging === 'undefined' || vscroll_enableLogging) {
+        scroller.logger.log(() => `fetch direction is "${direction}"`);
+      }
     }
   }
 
   static getStatus(scroller: Scroller): ProcessStatus {
     const { cycle, fetch } = scroller.state;
     if (cycle.initiator === AdapterProcess.clip) {
-      scroller.logger.log(() => `going to skip fetch due to "${AdapterProcess.clip}" process`);
+      if (typeof vscroll_enableLogging === 'undefined' || vscroll_enableLogging) {
+        scroller.logger.log(() => `going to skip fetch due to "${AdapterProcess.clip}" process`);
+      }
       return ProcessStatus.next;
     }
     if (fetch.shouldFetch) {
-      scroller.logger.log(() => `going to fetch ${fetch.count} items started from index ${fetch.index}`);
+      if (typeof vscroll_enableLogging === 'undefined' || vscroll_enableLogging) {
+        scroller.logger.log(() => `going to fetch ${fetch.count} items started from index ${fetch.index}`);
+      }
       return ProcessStatus.next;
     }
     return ProcessStatus.done;

--- a/src/processes/render.ts
+++ b/src/processes/render.ts
@@ -6,7 +6,9 @@ export default class Render extends BaseProcessFactory(CommonProcess.render) {
 
   static run(scroller: Scroller): void {
     const { workflow, state: { cycle, render, scroll, fetch }, viewport, routines } = scroller;
-    scroller.logger.stat('before new items render');
+    if (typeof vscroll_enableLogging === 'undefined' || vscroll_enableLogging) {
+      scroller.logger.stat('before new items render');
+    }
     if (scroll.positionBeforeAsync === null) {
       scroll.positionBeforeAsync = viewport.scrollPosition;
     }
@@ -41,8 +43,10 @@ export default class Render extends BaseProcessFactory(CommonProcess.render) {
     }
     buffer.checkDefaultSize();
     render.sizeAfter = viewport.getScrollableSize();
-    logger.stat('after new items render');
-    logger.log(() => render.noSize ? 'viewport size has not been changed' : void 0);
+    if (typeof vscroll_enableLogging === 'undefined' || vscroll_enableLogging) {
+      logger.stat('after new items render');
+      logger.log(() => render.noSize ? 'viewport size has not been changed' : void 0);
+    }
     return true;
   }
 

--- a/src/processes/scroll.ts
+++ b/src/processes/scroll.ts
@@ -27,14 +27,18 @@ export default class Scroll extends BaseProcessFactory(CommonProcess.scroll) {
         scroll.syntheticPosition = null;
       }
       if (!scroll.syntheticFulfill || synthPos === position) {
-        scroller.logger.log(() => [
-          'skipping scroll', position, `[${scroll.syntheticFulfill ? '' : 'pre-'}synthetic]`
-        ]);
+        if (typeof vscroll_enableLogging === 'undefined' || vscroll_enableLogging) {
+          scroller.logger.log(() => [
+            'skipping scroll', position, `[${scroll.syntheticFulfill ? '' : 'pre-'}synthetic]`
+          ]);
+        }
         return true;
       }
-      scroller.logger.log(() => [
-        'synthetic scroll has been fulfilled:', position, position < synthPos ? '<' : '>', synthPos
-      ]);
+      if (typeof vscroll_enableLogging === 'undefined' || vscroll_enableLogging) {
+        scroller.logger.log(() => [
+          'synthetic scroll has been fulfilled:', position, position < synthPos ? '<' : '>', synthPos
+        ]);
+      }
     }
     return false;
   }
@@ -47,12 +51,14 @@ export default class Scroll extends BaseProcessFactory(CommonProcess.scroll) {
     const delta = throttle - timeDiff;
     const shouldDelay = isFinite(delta) && delta > 0;
     const alreadyDelayed = !!scroll.scrollTimer;
-    logger.log(() => [
-      direction === Direction.backward ? '\u2934' : '\u2935',
-      position,
-      shouldDelay ? (timeDiff + 'ms') : '0ms',
-      shouldDelay ? (alreadyDelayed ? 'delayed' : `/ ${delta}ms delay`) : ''
-    ]);
+    if (typeof vscroll_enableLogging === 'undefined' || vscroll_enableLogging) {
+      logger.log(() => [
+        direction === Direction.backward ? '\u2934' : '\u2935',
+        position,
+        shouldDelay ? (timeDiff + 'ms') : '0ms',
+        shouldDelay ? (alreadyDelayed ? 'delayed' : `/ ${delta}ms delay`) : ''
+      ]);
+    }
     if (!shouldDelay) {
       if (scroll.scrollTimer) {
         clearTimeout(scroll.scrollTimer);
@@ -63,16 +69,18 @@ export default class Scroll extends BaseProcessFactory(CommonProcess.scroll) {
     }
     if (!alreadyDelayed) {
       scroll.scrollTimer = setTimeout(() => {
-        logger.log(() => {
-          const curr = Scroll.getScrollEvent(scroller.viewport.scrollPosition, scroll.current);
-          return [
-            curr.direction === Direction.backward ? '\u2934' : '\u2935',
-            curr.position,
-            (curr.time - time) + 'ms',
-            'triggered by timer set on',
-            position
-          ];
-        });
+        if (typeof vscroll_enableLogging === 'undefined' || vscroll_enableLogging) {
+          logger.log(() => {
+            const curr = Scroll.getScrollEvent(scroller.viewport.scrollPosition, scroll.current);
+            return [
+              curr.direction === Direction.backward ? '\u2934' : '\u2935',
+              curr.position,
+              (curr.time - time) + 'ms',
+              'triggered by timer set on',
+              position
+            ];
+          });
+        }
         scroll.scrollTimer = null;
         done();
       }, delta);
@@ -98,7 +106,9 @@ export default class Scroll extends BaseProcessFactory(CommonProcess.scroll) {
     scroll.current = null;
 
     if (cycle.busy.get()) {
-      scroller.logger.log(() => ['skipping scroll', (scroll.previous as ScrollEventData).position, '[pending]']);
+      if (typeof vscroll_enableLogging === 'undefined' || vscroll_enableLogging) {
+        scroller.logger.log(() => ['skipping scroll', (scroll.previous as ScrollEventData).position, '[pending]']);
+      }
       return;
     }
 

--- a/src/scroller.ts
+++ b/src/scroller.ts
@@ -55,12 +55,14 @@ export class Scroller<Data = unknown> {
 
     this.workflow = workflow;
     this.settings = new Settings<Data>(datasource.settings, datasource.devSettings, ++instanceCount);
-    this.logger = new Logger(this as Scroller, packageInfo, datasource.adapter);
+    this.logger = typeof vscroll_enableLogging === 'undefined' || vscroll_enableLogging ? new Logger(this as Scroller, packageInfo, datasource.adapter) : null!;
     this.routines = new (CustomRoutines || Routines)(element, this.settings);
     this.state = new State(packageInfo, this.settings, scroller ? scroller.state : void 0);
     this.buffer = new Buffer<Data>(this.settings, workflow.onDataChanged, this.logger);
     this.viewport = new Viewport(this.settings, this.routines, this.state, this.logger);
-    this.logger.object('vscroll settings object', this.settings, true);
+    if (typeof vscroll_enableLogging === 'undefined' || vscroll_enableLogging) {
+      this.logger.object('vscroll settings object', this.settings, true);
+    }
 
     this.initDatasource(datasource, scroller);
   }
@@ -90,7 +92,9 @@ export class Scroller<Data = unknown> {
 
   init(adapterRun$?: Reactive<ProcessSubject>): void {
     this.viewport.reset(this.buffer.startIndex);
-    this.logger.stat('initialization');
+    if (typeof vscroll_enableLogging === 'undefined' || vscroll_enableLogging) {
+      this.logger.stat('initialization');
+    }
     this.adapter.initialize({
       buffer: this.buffer,
       state: this.state,
@@ -101,7 +105,9 @@ export class Scroller<Data = unknown> {
   }
 
   dispose(forever?: boolean): void {
-    this.logger.log(() => 'disposing scroller' + (forever ? ' (forever)' : ''));
+    if (typeof vscroll_enableLogging === 'undefined' || vscroll_enableLogging) {
+      this.logger.log(() => 'disposing scroller' + (forever ? ' (forever)' : ''));
+    }
     if (forever) { // Adapter is not re-instantiated on reset
       this.adapter.dispose();
     }


### PR DESCRIPTION
This change introduces a compile-time `vscroll_enableLogging` flag to guard internal logging calls.

Previously, all logger calls (e.g., `this.logger.log(...)`) were evaluated at runtime, even if the logs were not needed in production. Some of these logs use lazy evaluation via closures, but the overhead of logging logic and potential string construction still existed.

By wrapping logger calls in `if (vscroll_enableLogging)` checks, bundlers like esbuild or Webpack can remove them entirely from production builds using dead code elimination. This reduces the bundle size and runtime cost for consumers who do not rely on internal logs.

Consumers can set the flag at build time using:

```js
// esbuild
define: {
  vscroll_enableLogging: JSON.stringify(false)
}

// Webpack DefinePlugin
new webpack.DefinePlugin({
  vscroll_enableLogging: JSON.stringify(false)
});
```

This change does not affect behavior in development builds where logging is still useful.